### PR TITLE
Fix release CI/CD

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -32,11 +32,6 @@ jobs:
         pip install build
     - name: Build package
       run: python -m build
-    - name: Publish package to *Test* PyPI
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-      with:
-        user: __token__
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .PHONY: build publish-test install lint test
 
 build:
+	rm -r dist/
+	rm -r build/
 	python -m build --sdist
 	python -m build --wheel
 	twine check dist/*


### PR DESCRIPTION
Don't publish to test PyPI on release.
Add clean commands in make recipe 'build'.